### PR TITLE
Rename entry to ChainEntry.

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -75,7 +75,7 @@ type ChainEntry struct {
 }
 
 // Info logs an entry with INFO level.
-func (e entry) Write() {
+func (e ChainEntry) Write() {
 	if e.disabled {
 		return
 	}

--- a/entry.go
+++ b/entry.go
@@ -4,11 +4,6 @@ import (
 	"github.com/francoispqt/gojay"
 )
 
-type entry struct {
-	Entry
-	disabled bool
-}
-
 // Entry is the structure wrapping a pointer to the current encoder.
 // It provides easy API to work with GoJay's encoder.
 type Entry struct {
@@ -72,7 +67,12 @@ func (e Entry) Array(k string, obj gojay.MarshalerJSONArray) Entry {
 	return e
 }
 
-// entry it is used when chaining
+// ChainEntry is for chaining calls to the entry.
+
+type ChainEntry struct {
+	Entry
+	disabled bool
+}
 
 // Info logs an entry with INFO level.
 func (e entry) Write() {
@@ -86,7 +86,7 @@ func (e entry) Write() {
 }
 
 // String adds a string to the log entry.
-func (e entry) String(k, v string) entry {
+func (e ChainEntry) String(k, v string) ChainEntry {
 	if e.disabled {
 		return e
 	}
@@ -95,7 +95,7 @@ func (e entry) String(k, v string) entry {
 }
 
 // Int adds an int to the log entry.
-func (e entry) Int(k string, v int) entry {
+func (e ChainEntry) Int(k string, v int) ChainEntry {
 	if e.disabled {
 		return e
 	}
@@ -104,7 +104,7 @@ func (e entry) Int(k string, v int) entry {
 }
 
 // Int64 adds an int64 to the log entry.
-func (e entry) Int64(k string, v int64) entry {
+func (e ChainEntry) Int64(k string, v int64) ChainEntry {
 	if e.disabled {
 		return e
 	}
@@ -113,7 +113,7 @@ func (e entry) Int64(k string, v int64) entry {
 }
 
 // Float adds a float64 to the log entry.
-func (e entry) Float(k string, v float64) entry {
+func (e ChainEntry) Float(k string, v float64) ChainEntry {
 	if e.disabled {
 		return e
 	}
@@ -122,7 +122,7 @@ func (e entry) Float(k string, v float64) entry {
 }
 
 // Bool adds a bool to the log entry.
-func (e entry) Bool(k string, v bool) entry {
+func (e ChainEntry) Bool(k string, v bool) ChainEntry {
 	if e.disabled {
 		return e
 	}
@@ -131,7 +131,7 @@ func (e entry) Bool(k string, v bool) entry {
 }
 
 // Error adds an error to the log entry.
-func (e entry) Err(k string, v error) entry {
+func (e ChainEntry) Err(k string, v error) ChainEntry {
 	if e.disabled {
 		return e
 	}
@@ -140,7 +140,7 @@ func (e entry) Err(k string, v error) entry {
 }
 
 // ObjectFunc adds an object to the log entry by calling a function.
-func (e entry) ObjectFunc(k string, v func(Entry)) entry {
+func (e ChainEntry) ObjectFunc(k string, v func(Entry)) ChainEntry {
 	if e.disabled {
 		return e
 	}
@@ -151,7 +151,7 @@ func (e entry) ObjectFunc(k string, v func(Entry)) entry {
 }
 
 // Object adds an object to the log entry by passing an implementation of gojay.MarshalerJSONObject.
-func (e entry) Object(k string, obj gojay.MarshalerJSONObject) entry {
+func (e ChainEntry) Object(k string, obj gojay.MarshalerJSONObject) ChainEntry {
 	if e.disabled {
 		return e
 	}
@@ -160,7 +160,7 @@ func (e entry) Object(k string, obj gojay.MarshalerJSONObject) entry {
 }
 
 // Array adds an object to the log entry by passing an implementation of gojay.MarshalerJSONObject.
-func (e entry) Array(k string, obj gojay.MarshalerJSONArray) entry {
+func (e ChainEntry) Array(k string, obj gojay.MarshalerJSONArray) ChainEntry {
 	if e.disabled {
 		return e
 	}
@@ -169,7 +169,7 @@ func (e entry) Array(k string, obj gojay.MarshalerJSONArray) entry {
 }
 
 // Any adds anything stuff to the log entry based on it's type
-func (e entry) Any(k string, obj interface{}) entry {
+func (e ChainEntry) Any(k string, obj interface{}) ChainEntry {
 	if e.disabled {
 		return e
 	}

--- a/entry_test.go
+++ b/entry_test.go
@@ -138,13 +138,13 @@ func TestEntryFields(t *testing.T) {
 		level       uint8
 		disabled    uint8
 		levelString string
-		entryFunc   func(*Logger) entry
+		entryFunc   func(*Logger) ChainEntry
 	}{
 		{
 			level:       INFO,
 			disabled:    DEBUG,
 			levelString: "info",
-			entryFunc: func(l *Logger) entry {
+			entryFunc: func(l *Logger) ChainEntry {
 				return l.InfoWith("hello")
 			},
 		},
@@ -152,7 +152,7 @@ func TestEntryFields(t *testing.T) {
 			level:       DEBUG,
 			disabled:    INFO,
 			levelString: "debug",
-			entryFunc: func(l *Logger) entry {
+			entryFunc: func(l *Logger) ChainEntry {
 				return l.DebugWith("hello")
 			},
 		},
@@ -160,7 +160,7 @@ func TestEntryFields(t *testing.T) {
 			level:       WARN,
 			disabled:    ERROR,
 			levelString: "warn",
-			entryFunc: func(l *Logger) entry {
+			entryFunc: func(l *Logger) ChainEntry {
 				return l.WarnWith("hello")
 			},
 		},
@@ -168,7 +168,7 @@ func TestEntryFields(t *testing.T) {
 			level:       ERROR,
 			disabled:    WARN,
 			levelString: "error",
-			entryFunc: func(l *Logger) entry {
+			entryFunc: func(l *Logger) ChainEntry {
 				return l.ErrorWith("hello")
 			},
 		},
@@ -176,7 +176,7 @@ func TestEntryFields(t *testing.T) {
 			level:       FATAL,
 			disabled:    ERROR,
 			levelString: "fatal",
-			entryFunc: func(l *Logger) entry {
+			entryFunc: func(l *Logger) ChainEntry {
 				return l.FatalWith("hello")
 			},
 		},

--- a/logger.go
+++ b/logger.go
@@ -99,11 +99,11 @@ func (l *Logger) Info(msg string) {
 	enc.Release()
 }
 
-// InfoWith return an entry with INFO level.
-func (l *Logger) InfoWith(msg string) entry {
+// InfoWith return an ChainEntry with INFO level.
+func (l *Logger) InfoWith(msg string) ChainEntry {
 	// first find writer for level
 	// if none, stop
-	e := entry{
+	e := ChainEntry{
 		Entry: Entry{
 			l: l,
 		},
@@ -161,11 +161,11 @@ func (l *Logger) Debug(msg string) {
 	enc.Release()
 }
 
-// DebugWith return entry with DEBUG level.
-func (l *Logger) DebugWith(msg string) entry {
+// DebugWith return ChainEntry with DEBUG level.
+func (l *Logger) DebugWith(msg string) ChainEntry {
 	// first find writer for level
 	// if none, stop
-	e := entry{
+	e := ChainEntry{
 		Entry: Entry{
 			l: l,
 		},
@@ -223,11 +223,11 @@ func (l *Logger) Warn(msg string) {
 	enc.Release()
 }
 
-// WarnWith returns entry with WARN level
-func (l *Logger) WarnWith(msg string) entry {
+// WarnWith returns a ChainEntry with WARN level
+func (l *Logger) WarnWith(msg string) ChainEntry {
 	// first find writer for level
 	// if none, stop
-	e := entry{
+	e := ChainEntry{
 		Entry: Entry{
 			l: l,
 		},
@@ -281,11 +281,11 @@ func (l *Logger) Error(msg string) {
 	enc.Release()
 }
 
-// ErrorWith returns entry with ERROR level.
-func (l *Logger) ErrorWith(msg string) entry {
+// ErrorWith returns a ChainEntry with ERROR level.
+func (l *Logger) ErrorWith(msg string) ChainEntry {
 	// first find writer for level
 	// if none, stop
-	e := entry{
+	e := ChainEntry{
 		Entry: Entry{
 			l: l,
 		},
@@ -339,11 +339,11 @@ func (l *Logger) Fatal(msg string) {
 	enc.Release()
 }
 
-// FatalWith returns entry with FATAL level.
-func (l *Logger) FatalWith(msg string) entry {
+// FatalWith returns a ChainEntry with FATAL level.
+func (l *Logger) FatalWith(msg string) ChainEntry {
 	// first find writer for level
 	// if none, stop
-	e := entry{
+	e := ChainEntry{
 		Entry: Entry{
 			l: l,
 		},


### PR DESCRIPTION
The `DebugWith` and related functions currently return the unexposed `entry` type. This PR exposes the chain entry as `ChainEntry`, which allows users to wrap these commands.

For example the following is now possible:

```
type interface MyLogEntry {
    String("key", "value") MyLogEntry
}

type onelogEntry struct {
    entry onelog.ChainEntry
}

func (e *onelogEntry) String(k string, v string) MyLogEntry {
    return &onelogEntry{entry: e.entry.String(k, v)}
}
```
For users that want to abstract away the actual log implementation that is being used.