### PR TITLE
default output ioutil.Discard

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -2,6 +2,7 @@ package onelog
 
 import (
 	"io"
+	"io/ioutil"
 	"runtime"
 	"strconv"
 
@@ -45,6 +46,10 @@ type Logger struct {
 
 // New returns a fresh onelog Logger with default values.
 func New(w io.Writer, levels uint8) *Logger {
+	if w == nil {
+		w = ioutil.Discard
+	}
+
 	return &Logger{
 		levels: levels,
 		w:      w,

--- a/logger_test.go
+++ b/logger_test.go
@@ -519,3 +519,10 @@ func TestOnelogContext(t *testing.T) {
 		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
 	})
 }
+
+func TestNilOutput(t *testing.T) {
+	logger := New(nil, 0)
+	assert.NotNil(t, logger.w, "Logger output should not be nil")
+	logger.Error("Test output")
+	t.Log("Successfully write to ioutil.Discard output")
+}


### PR DESCRIPTION
if a nil io.Writer is provided, then use ioutil.Discard
which will discard all output.  This will avoid a panic
when writing to a nil interface

https://github.com/francoispqt/onelog/issues/13