### PR TITLE
ORCA-619: Add context based logging to onelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ func main() {
 }
 ```
 
+
 ## Levels
 
 Levels are ints mapped to a string. The logger will check if level is enabled with an efficient bitwise &(AND), if disabled, it returns right away which makes onelog the fastest when running disabled logging with 0 allocs and less than 1ns/op. [See benchmarks](#benchmarks)
@@ -101,6 +102,49 @@ logger.Hook(func(e onelog.Entry) {
     e.String("time", time.Now().Format(time.RFC3339))
 })
 logger.Info("hello world !") // {"level":"info","message":"hello world","time":"2018-05-06T02:21:01+08:00"}
+```
+
+## Context
+
+Context allows enforcing a grouping format where all logs fields key-values pairs from all logging methods (With, Info, Debug, InfoWith, InfoWithEntry, ...etc) except
+for values from using `logger.Hook`, will be enclosed in giving context name provided as it's key. For example using a context key "params" as below
+
+
+```go
+logger := onelog.NewContext(
+    os.Stdout, 
+    onelog.INFO|onelog.WARN,
+    "params"
+)
+
+logger.InfoWithFields("breaking news !", func(e onelog.Entry) {
+    e.String("userID", "123455")
+}) 
+
+// {"level":"info","message":"breaking news !", "params":{"userID":"123456"}}
+```
+
+This principle also applies when inheriting from a previous created logger as below
+
+```go
+parentLogger := onelog.New(
+    os.Stdout, 
+    onelog.INFO|onelog.WARN,
+)
+
+
+logger := parentLogger.WithContext("params")
+logger.InfoWithFields("breaking news !", func(e onelog.Entry) {
+    e.String("userID", "123455")
+}) 
+
+// {"level":"info","message":"breaking news !", "params":{"userID":"123456"}}
+```
+
+
+You can always reset the context by calling `WithContext("")` to create a no-context logger from a 
+context logger parent.
+
 ```
 
 ## Logging

--- a/entry.go
+++ b/entry.go
@@ -7,9 +7,10 @@ import (
 // Entry is the structure wrapping a pointer to the current encoder.
 // It provides easy API to work with GoJay's encoder.
 type Entry struct {
-	enc   *Encoder
-	l     *Logger
-	Level uint8
+	enc     *Encoder
+	l       *Logger
+	Level   uint8
+	Message string
 }
 
 // String adds a string to the log entry.
@@ -84,6 +85,7 @@ func (e ChainEntry) Write() {
 	// first find writer for level
 	// if none, stop
 	e.Entry.l.closeEntry(e.enc)
+	e.Entry.l.finalizeIfContext(e.Entry)
 	e.Entry.enc.Release()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/gokit/onelog
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/francoispqt/gojay v0.0.0-20181018093702-688c5d008625
+	github.com/francoispqt/onelog v0.0.0-20181018141347-eb9cb127e764
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/francoispqt/gojay v0.0.0-20181018093702-688c5d008625 h1:uhhBCKCbZlCe/jESjdgjGfHxnjC0cXyf/M0EmyenOpg=
+github.com/francoispqt/gojay v0.0.0-20181018093702-688c5d008625/go.mod h1:H8Wgri1Asi1VevY3ySdpIK5+KCpqzToVswNq8g2xZj4=
+github.com/francoispqt/onelog v0.0.0-20181018141347-eb9cb127e764 h1:zruWflCw1EHkg2cS7qP8qmUQ42e6/EQLR8npm2pwiQE=
+github.com/francoispqt/onelog v0.0.0-20181018141347-eb9cb127e764/go.mod h1:YawD7stzYj2osdt+5afKe//+bGLd3mdDtYFxsYiY118=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/logger.go
+++ b/logger.go
@@ -86,6 +86,17 @@ func (l *Logger) With(f func(Entry)) *Logger {
 	return nL
 }
 
+// WithContext copies current logger enforcing all entry fields to be
+// set into a map with the contextName set as the key name for giving map.
+// This allows allocating all future uses of the logging methods to
+// follow such formatting. The only exception are values provided by
+// added hooks which will remain within the root level of generated json.
+func (l *Logger) WithContext(contextName string) *Logger {
+	nl := l.copy()
+
+	return nl
+}
+
 // Info logs an entry with INFO level.
 func (l *Logger) Info(msg string) {
 	// first find writer for level

--- a/logger.go
+++ b/logger.go
@@ -9,7 +9,9 @@ import (
 	"github.com/francoispqt/gojay"
 )
 
+var logOpen = []byte("{")
 var logClose = []byte("}\n")
+var logCloseOnly = []byte("}")
 var msgKey = "message"
 
 // LevelText personalises the text for a specific level.
@@ -38,10 +40,11 @@ type Object = gojay.EncodeObjectFunc
 
 // Logger is the type representing a logger.
 type Logger struct {
-	hook   func(Entry)
-	w      io.Writer
-	levels uint8
-	ctx    []byte
+	hook        func(Entry)
+	w           io.Writer
+	levels      uint8
+	ctx         []byte
+	contextName string
 }
 
 // New returns a fresh onelog Logger with default values.
@@ -51,8 +54,22 @@ func New(w io.Writer, levels uint8) *Logger {
 	}
 
 	return &Logger{
-		levels: levels,
 		w:      w,
+		levels: levels,
+	}
+}
+
+// NewContext returns a fresh onelog Logger with default values and
+// context name set to provided contextName value.
+func NewContext(w io.Writer, levels uint8, contextName string) *Logger {
+	if w == nil {
+		w = ioutil.Discard
+	}
+
+	return &Logger{
+		w:           w,
+		levels:      levels,
+		contextName: contextName,
 	}
 }
 
@@ -62,23 +79,26 @@ func (l *Logger) Hook(h func(Entry)) *Logger {
 	return l
 }
 
-func (l *Logger) copy() *Logger {
+func (l *Logger) copy(ctxName string) *Logger {
 	nL := Logger{
-		levels: l.levels,
-		w:      l.w,
-		hook:   l.hook,
+		levels:      l.levels,
+		w:           l.w,
+		hook:        l.hook,
+		contextName: ctxName,
 	}
 	return &nL
 }
 
 // With copies the current Logger and adds it a given context by running func f.
 func (l *Logger) With(f func(Entry)) *Logger {
-	nL := l.copy()
-	e := Entry{}
+	nL := l.copy(l.contextName)
 	enc := gojay.NewEncoder(nL.w)
+
+	e := Entry{}
 	e.enc = enc
 	enc.AppendByte(' ')
 	f(e)
+
 	b := enc.Buf()
 	nL.ctx = make([]byte, len(b[1:]))
 	copy(nL.ctx, b[1:])
@@ -92,8 +112,7 @@ func (l *Logger) With(f func(Entry)) *Logger {
 // follow such formatting. The only exception are values provided by
 // added hooks which will remain within the root level of generated json.
 func (l *Logger) WithContext(contextName string) *Logger {
-	nl := l.copy()
-
+	nl := l.copy(contextName)
 	return nl
 }
 
@@ -104,15 +123,22 @@ func (l *Logger) Info(msg string) {
 	if INFO&l.levels == 0 {
 		return
 	}
-	e := Entry{Level: INFO}
+	e := Entry{Level: INFO, Message: msg}
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.enc = enc
-	l.beginEntry(INFO, msg, enc)
-	if l.hook != nil {
-		l.hook(e)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e)
+	} else {
+		l.openEntry(enc)
 	}
+
 	l.closeEntry(enc)
+	l.finalizeIfContext(e)
 	enc.Release()
 }
 
@@ -122,21 +148,28 @@ func (l *Logger) InfoWith(msg string) ChainEntry {
 	// if none, stop
 	e := ChainEntry{
 		Entry: Entry{
-			l:     l,
-			Level: INFO,
+			l:       l,
+			Level:   INFO,
+			Message: msg,
 		},
 	}
 	e.disabled = INFO&e.l.levels == 0
 	if e.disabled {
 		return e
 	}
-	// then call format on formatter
+
 	enc := gojay.BorrowEncoder(l.w)
 	e.Entry.enc = enc
-	l.beginEntry(INFO, msg, enc)
-	if l.hook != nil {
-		l.hook(e.Entry)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e.Entry)
+		return e
 	}
+
+	l.openEntry(enc)
 	return e
 }
 
@@ -147,16 +180,23 @@ func (l *Logger) InfoWithFields(msg string, fields func(Entry)) {
 	if INFO&l.levels == 0 {
 		return
 	}
-	e := Entry{Level: INFO}
+	e := Entry{Level: INFO, Message: msg}
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.enc = enc
-	l.beginEntry(INFO, msg, enc)
-	if l.hook != nil {
-		l.hook(e)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e)
+	} else {
+		l.openEntry(enc)
 	}
+
 	fields(e)
 	l.closeEntry(enc)
+	l.finalizeIfContext(e)
 	enc.Release()
 }
 
@@ -167,15 +207,22 @@ func (l *Logger) Debug(msg string) {
 	if DEBUG&l.levels == 0 {
 		return
 	}
-	e := Entry{Level: DEBUG}
+	e := Entry{Level: DEBUG, Message: msg}
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.enc = enc
-	l.beginEntry(DEBUG, msg, enc)
-	if l.hook != nil {
-		l.hook(e)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e)
+	} else {
+		l.openEntry(enc)
 	}
+
 	l.closeEntry(enc)
+	l.finalizeIfContext(e)
 	enc.Release()
 }
 
@@ -185,7 +232,9 @@ func (l *Logger) DebugWith(msg string) ChainEntry {
 	// if none, stop
 	e := ChainEntry{
 		Entry: Entry{
-			l: l,
+			l:       l,
+			Level:   DEBUG,
+			Message: msg,
 		},
 	}
 	e.disabled = DEBUG&e.l.levels == 0
@@ -195,10 +244,16 @@ func (l *Logger) DebugWith(msg string) ChainEntry {
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.Entry.enc = enc
-	l.beginEntry(DEBUG, msg, enc)
-	if l.hook != nil {
-		l.hook(e.Entry)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e.Entry)
+		return e
 	}
+
+	l.openEntry(enc)
 	return e
 }
 
@@ -209,16 +264,23 @@ func (l *Logger) DebugWithFields(msg string, fields func(Entry)) {
 	if DEBUG&l.levels == 0 {
 		return
 	}
-	e := Entry{Level: DEBUG}
+	e := Entry{Level: DEBUG, Message: msg}
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.enc = enc
-	l.beginEntry(DEBUG, msg, enc)
-	if l.hook != nil {
-		l.hook(e)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e)
+	} else {
+		l.openEntry(enc)
 	}
+
 	fields(e)
 	l.closeEntry(enc)
+	l.finalizeIfContext(e)
 	enc.Release()
 }
 
@@ -229,15 +291,22 @@ func (l *Logger) Warn(msg string) {
 	if WARN&l.levels == 0 {
 		return
 	}
-	e := Entry{Level: WARN}
+	e := Entry{Level: WARN, Message: msg}
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.enc = enc
-	l.beginEntry(WARN, msg, enc)
-	if l.hook != nil {
-		l.hook(e)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e)
+	} else {
+		l.openEntry(enc)
 	}
+
 	l.closeEntry(enc)
+	l.finalizeIfContext(e)
 	enc.Release()
 }
 
@@ -247,8 +316,9 @@ func (l *Logger) WarnWith(msg string) ChainEntry {
 	// if none, stop
 	e := ChainEntry{
 		Entry: Entry{
-			l:     l,
-			Level: WARN,
+			l:       l,
+			Level:   WARN,
+			Message: msg,
 		},
 	}
 	e.disabled = WARN&e.l.levels == 0
@@ -258,10 +328,16 @@ func (l *Logger) WarnWith(msg string) ChainEntry {
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.Entry.enc = enc
-	l.beginEntry(WARN, msg, enc)
-	if l.hook != nil {
-		l.hook(e.Entry)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e.Entry)
+		return e
 	}
+
+	l.openEntry(enc)
 	return e
 }
 
@@ -271,17 +347,25 @@ func (l *Logger) WarnWithFields(msg string, fields func(Entry)) {
 		return
 	}
 	e := Entry{
-		Level: WARN,
+		Level:   WARN,
+		Message: msg,
 	}
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.enc = enc
-	l.beginEntry(WARN, msg, enc)
-	if l.hook != nil {
-		l.hook(e)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e)
+	} else {
+		l.openEntry(enc)
 	}
+
 	fields(e)
 	l.closeEntry(enc)
+	l.finalizeIfContext(e)
 	enc.Release()
 }
 
@@ -291,16 +375,24 @@ func (l *Logger) Error(msg string) {
 		return
 	}
 	e := Entry{
-		Level: ERROR,
+		Level:   ERROR,
+		Message: msg,
 	}
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.enc = enc
-	l.beginEntry(ERROR, msg, enc)
-	if l.hook != nil {
-		l.hook(e)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e)
+	} else {
+		l.openEntry(enc)
 	}
+
 	l.closeEntry(enc)
+	l.finalizeIfContext(e)
 	enc.Release()
 }
 
@@ -310,8 +402,9 @@ func (l *Logger) ErrorWith(msg string) ChainEntry {
 	// if none, stop
 	e := ChainEntry{
 		Entry: Entry{
-			l:     l,
-			Level: ERROR,
+			l:       l,
+			Level:   ERROR,
+			Message: msg,
 		},
 	}
 	e.disabled = ERROR&e.l.levels == 0
@@ -321,10 +414,16 @@ func (l *Logger) ErrorWith(msg string) ChainEntry {
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.Entry.enc = enc
-	l.beginEntry(ERROR, msg, enc)
-	if l.hook != nil {
-		l.hook(e.Entry)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e.Entry)
+		return e
 	}
+
+	l.openEntry(enc)
 	return e
 }
 
@@ -334,17 +433,25 @@ func (l *Logger) ErrorWithFields(msg string, fields func(Entry)) {
 		return
 	}
 	e := Entry{
-		Level: ERROR,
+		Level:   ERROR,
+		Message: msg,
 	}
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.enc = enc
-	l.beginEntry(ERROR, msg, enc)
-	if l.hook != nil {
-		l.hook(e)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e)
+	} else {
+		l.openEntry(enc)
 	}
+
 	fields(e)
 	l.closeEntry(enc)
+	l.finalizeIfContext(e)
 	enc.Release()
 }
 
@@ -354,16 +461,24 @@ func (l *Logger) Fatal(msg string) {
 		return
 	}
 	e := Entry{
-		Level: FATAL,
+		Level:   FATAL,
+		Message: msg,
 	}
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.enc = enc
-	l.beginEntry(FATAL, msg, enc)
-	if l.hook != nil {
-		l.hook(e)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e)
+	} else {
+		l.openEntry(enc)
 	}
+
 	l.closeEntry(enc)
+	l.finalizeIfContext(e)
 	enc.Release()
 }
 
@@ -373,7 +488,9 @@ func (l *Logger) FatalWith(msg string) ChainEntry {
 	// if none, stop
 	e := ChainEntry{
 		Entry: Entry{
-			l: l,
+			l:       l,
+			Level:   FATAL,
+			Message: msg,
 		},
 	}
 	e.disabled = FATAL&e.l.levels == 0
@@ -383,10 +500,16 @@ func (l *Logger) FatalWith(msg string) ChainEntry {
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.Entry.enc = enc
-	l.beginEntry(FATAL, msg, enc)
-	if l.hook != nil {
-		l.hook(e.Entry)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e.Entry)
+		return e
 	}
+
+	l.openEntry(enc)
 	return e
 }
 
@@ -395,32 +518,91 @@ func (l *Logger) FatalWithFields(msg string, fields func(Entry)) {
 	if FATAL&l.levels == 0 {
 		return
 	}
+
 	e := Entry{
-		Level: FATAL,
+		Level:   FATAL,
+		Message: msg,
 	}
+
 	// then call format on formatter
 	enc := gojay.BorrowEncoder(l.w)
 	e.enc = enc
-	l.beginEntry(FATAL, msg, enc)
-	if l.hook != nil {
-		l.hook(e)
+
+	// if we do not require a context then we
+	// format with formatter and return.
+	if l.contextName == "" {
+		l.beginEntry(e.Level, msg, enc)
+		l.runHook(e)
+	} else {
+		l.openEntry(enc)
 	}
+
 	fields(e)
 	l.closeEntry(enc)
+	l.finalizeIfContext(e)
 	enc.Release()
+}
+
+func (l *Logger) openEntry(enc *Encoder) {
+	enc.AppendBytes(logOpen)
 }
 
 func (l *Logger) beginEntry(level uint8, msg string, enc *Encoder) {
 	enc.AppendBytes(levelsJSON[level])
 	enc.AppendString(msg)
-	if l.ctx != nil {
+
+	if l.ctx != nil && l.contextName == "" {
 		enc.AppendBytes(l.ctx)
 	}
 }
 
-func (l Logger) closeEntry(enc *Encoder) {
-	enc.AppendBytes(logClose)
-	enc.Write()
+func (l Logger) runHook(e Entry) {
+	if l.hook == nil {
+		return
+	}
+	l.hook(e)
+}
+
+func (l *Logger) finalizeIfContext(entry Entry) {
+	if l.contextName == "" {
+		return
+	}
+
+	embeddedEnc := entry.enc
+
+	// create a new encoder for the final output.
+	entryEnc := gojay.BorrowEncoder(l.w)
+	entry.enc = entryEnc
+
+	// create dummy entry for applying hooks.
+	l.beginEntry(entry.Level, entry.Message, entryEnc)
+	l.runHook(entry)
+
+	// Add entry's encoded data into new encoder.
+	var embeddedJSON = gojay.EmbeddedJSON(embeddedEnc.Buf())
+	entryEnc.AddEmbeddedJSONKey(l.contextName, &embeddedJSON)
+
+	// close new encoder context for proper json.
+	entryEnc.AppendBytes(logClose)
+
+	// we need to manually write output as logger
+	// has context.
+	entryEnc.Write()
+}
+
+func (l *Logger) closeEntry(enc *Encoder) {
+	if l.contextName == "" {
+		enc.AppendBytes(logClose)
+	} else {
+		if l.ctx != nil {
+			enc.AppendBytes(l.ctx)
+		}
+		enc.AppendBytes(logCloseOnly)
+	}
+
+	if l.contextName == "" {
+		enc.Write()
+	}
 }
 
 // Caller returns the caller in the stack trace, skipped n times.

--- a/logger_test.go
+++ b/logger_test.go
@@ -813,3 +813,137 @@ func TestOnelogWithFieldsAndContext(t *testing.T) {
 		assert.False(t, w.called, "writer should not be called")
 	})
 }
+
+func TestOnelogNoContextFromContextLogger(t *testing.T) {
+	t.Run("fields-info", func(t *testing.T) {
+		testObj := &TestObj{foo: "bar"}
+		testArr := TestObjArr{testObj}
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.WithContext("")
+		logger.InfoWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+			e.Int("count", 100)
+			e.Int64("int64", 100)
+			e.Float("float64", 0.15)
+			e.Bool("done", true)
+			e.Err("error", errors.New("some error"))
+			e.ObjectFunc("user", func(e Entry) {
+				e.String("name", "somename")
+			})
+			e.Object("testObj", testObj)
+			e.Array("testArr", testArr)
+		})
+		json := `{"level":"info","message":"message","userID":"123456",` +
+			`"action":"login","result":"success","count":100,"int64":100,"float64":0.15,"done":true,` +
+			`"error":"some error","user":{"name":"somename"},"testObj":{"foo":"bar"},` +
+			`"testArr":[{"foo":"bar"}]}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-debug", func(t *testing.T) {
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.WithContext("")
+		logger.DebugWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		json := `{"level":"debug","message":"message","userID":"123456","action":"login","result":"success"}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-warn", func(t *testing.T) {
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.WithContext("")
+		logger.WarnWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		json := `{"level":"warn","message":"message","userID":"123456","action":"login","result":"success"}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-error", func(t *testing.T) {
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.WithContext("")
+		logger.ErrorWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		json := `{"level":"error","message":"message","userID":"123456","action":"login","result":"success"}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-fatal", func(t *testing.T) {
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.WithContext("")
+		logger.FatalWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+			e.Int64("int64", 120)
+		})
+		json := `{"level":"fatal","message":"message","userID":"123456","action":"login","result":"success","int64":120}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-disabled-level-info", func(t *testing.T) {
+		w := newWriter()
+		logger := New(w, DEBUG|WARN|ERROR|FATAL)
+		logger.InfoWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		assert.Equal(t, string(w.b), ``, "bytes written to the writer dont equal expected result")
+		assert.False(t, w.called, "writer should not be called")
+	})
+	t.Run("basic-message-disabled-level-debug", func(t *testing.T) {
+		w := newWriter()
+		logger := New(w, INFO|WARN|ERROR|FATAL)
+		logger.DebugWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		assert.Equal(t, string(w.b), ``, "bytes written to the writer dont equal expected result")
+		assert.False(t, w.called, "writer should not be called")
+	})
+	t.Run("basic-message-disabled-level-warn", func(t *testing.T) {
+		w := newWriter()
+		logger := New(w, INFO|DEBUG|ERROR|FATAL)
+		logger.WarnWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		assert.Equal(t, string(w.b), ``, "bytes written to the writer dont equal expected result")
+		assert.False(t, w.called, "writer should not be called")
+	})
+	t.Run("basic-message-disabled-level-error", func(t *testing.T) {
+		w := newWriter()
+		logger := New(w, INFO|WARN|DEBUG|FATAL)
+		logger.ErrorWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		assert.Equal(t, string(w.b), ``, "bytes written to the writer dont equal expected result")
+		assert.False(t, w.called, "writer should not be called")
+	})
+	t.Run("basic-message-disabled-level-fatal", func(t *testing.T) {
+		w := newWriter()
+		logger := New(w, INFO|WARN|ERROR|DEBUG)
+		logger.FatalWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		assert.Equal(t, string(w.b), ``, "bytes written to the writer dont equal expected result")
+		assert.False(t, w.called, "writer should not be called")
+	})
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -526,3 +526,290 @@ func TestNilOutput(t *testing.T) {
 	logger.Error("Test output")
 	t.Log("Successfully write to ioutil.Discard output")
 }
+
+func TestOnelogHooksWithAndContext(t *testing.T) {
+	t.Run("fields-info", func(t *testing.T) {
+		testObj := &TestObj{foo: "bar"}
+		testArr := TestObjArr{testObj}
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.Hook(func(e Entry) { e.Int("thunder_frequency", 1000) })
+		logger.InfoWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+			e.Int("count", 100)
+			e.Int64("int64", 100)
+			e.Float("float64", 0.15)
+			e.Bool("done", true)
+			e.Err("error", errors.New("some error"))
+			e.ObjectFunc("user", func(e Entry) {
+				e.String("name", "somename")
+			})
+			e.Object("testObj", testObj)
+			e.Array("testArr", testArr)
+		})
+		json := `{"level":"info","message":"message","thunder_frequency":1000,"params":{"userID":"123456",` +
+			`"action":"login","result":"success","count":100,"int64":100,"float64":0.15,"done":true,` +
+			`"error":"some error","user":{"name":"somename"},"testObj":{"foo":"bar"},` +
+			`"testArr":[{"foo":"bar"}]}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-debug", func(t *testing.T) {
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.Hook(func(e Entry) { e.Int("thunder_frequency", 1000) })
+		logger.DebugWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		json := `{"level":"debug","message":"message","thunder_frequency":1000,"params":{"userID":"123456","action":"login","result":"success"}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-warn", func(t *testing.T) {
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.Hook(func(e Entry) { e.Int("thunder_frequency", 1000) })
+		logger.WarnWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		json := `{"level":"warn","message":"message","thunder_frequency":1000,"params":{"userID":"123456","action":"login","result":"success"}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-error", func(t *testing.T) {
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.Hook(func(e Entry) { e.Int("thunder_frequency", 1000) })
+		logger.ErrorWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		json := `{"level":"error","message":"message","thunder_frequency":1000,"params":{"userID":"123456","action":"login","result":"success"}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-fatal", func(t *testing.T) {
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.Hook(func(e Entry) { e.Int("thunder_frequency", 1000) })
+		logger.FatalWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+			e.Int64("int64", 120)
+		})
+		json := `{"level":"fatal","message":"message","thunder_frequency":1000,"params":{"userID":"123456","action":"login","result":"success","int64":120}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+}
+
+func TestOnelogWithAndContext(t *testing.T) {
+	t.Run("fields-info", func(t *testing.T) {
+		testObj := &TestObj{foo: "bar"}
+		testArr := TestObjArr{testObj}
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.With(func(e Entry) { e.Int("thunder_frequency", 1000) })
+		logger.InfoWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+			e.Int("count", 100)
+			e.Int64("int64", 100)
+			e.Float("float64", 0.15)
+			e.Bool("done", true)
+			e.Err("error", errors.New("some error"))
+			e.ObjectFunc("user", func(e Entry) {
+				e.String("name", "somename")
+			})
+			e.Object("testObj", testObj)
+			e.Array("testArr", testArr)
+		})
+		json := `{"level":"info","message":"message","params":{"userID":"123456",` +
+			`"action":"login","result":"success","count":100,"int64":100,"float64":0.15,"done":true,` +
+			`"error":"some error","user":{"name":"somename"},"testObj":{"foo":"bar"},` +
+			`"testArr":[{"foo":"bar"}],"thunder_frequency":1000}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-debug", func(t *testing.T) {
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.With(func(e Entry) { e.Int("thunder_frequency", 1000) })
+		logger.DebugWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		json := `{"level":"debug","message":"message","params":{"userID":"123456","action":"login","result":"success","thunder_frequency":1000}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-warn", func(t *testing.T) {
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.With(func(e Entry) { e.Int("thunder_frequency", 1000) })
+		logger.WarnWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		json := `{"level":"warn","message":"message","params":{"userID":"123456","action":"login","result":"success","thunder_frequency":1000}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-error", func(t *testing.T) {
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.With(func(e Entry) { e.Int("thunder_frequency", 1000) })
+		logger.ErrorWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		json := `{"level":"error","message":"message","params":{"userID":"123456","action":"login","result":"success","thunder_frequency":1000}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-fatal", func(t *testing.T) {
+		w := newWriter()
+		parent := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger := parent.With(func(e Entry) { e.Int("thunder_frequency", 1000) })
+		logger.FatalWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+			e.Int64("int64", 120)
+		})
+		json := `{"level":"fatal","message":"message","params":{"userID":"123456","action":"login","result":"success","int64":120,"thunder_frequency":1000}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+}
+
+func TestOnelogWithFieldsAndContext(t *testing.T) {
+	t.Run("fields-info", func(t *testing.T) {
+		testObj := &TestObj{foo: "bar"}
+		testArr := TestObjArr{testObj}
+		w := newWriter()
+		logger := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger.InfoWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+			e.Int("count", 100)
+			e.Int64("int64", 100)
+			e.Float("float64", 0.15)
+			e.Bool("done", true)
+			e.Err("error", errors.New("some error"))
+			e.ObjectFunc("user", func(e Entry) {
+				e.String("name", "somename")
+			})
+			e.Object("testObj", testObj)
+			e.Array("testArr", testArr)
+		})
+		json := `{"level":"info","message":"message","params":{"userID":"123456",` +
+			`"action":"login","result":"success","count":100,"int64":100,"float64":0.15,"done":true,` +
+			`"error":"some error","user":{"name":"somename"},"testObj":{"foo":"bar"},` +
+			`"testArr":[{"foo":"bar"}]}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-debug", func(t *testing.T) {
+		w := newWriter()
+		logger := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger.DebugWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		json := `{"level":"debug","message":"message","params":{"userID":"123456","action":"login","result":"success"}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-warn", func(t *testing.T) {
+		w := newWriter()
+		logger := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger.WarnWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		json := `{"level":"warn","message":"message","params":{"userID":"123456","action":"login","result":"success"}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-error", func(t *testing.T) {
+		w := newWriter()
+		logger := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger.ErrorWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		json := `{"level":"error","message":"message","params":{"userID":"123456","action":"login","result":"success"}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-fatal", func(t *testing.T) {
+		w := newWriter()
+		logger := NewContext(w, DEBUG|INFO|WARN|ERROR|FATAL, "params")
+		logger.FatalWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+			e.Int64("int64", 120)
+		})
+		json := `{"level":"fatal","message":"message","params":{"userID":"123456","action":"login","result":"success","int64":120}}` + "\n"
+		assert.Equal(t, json, string(w.b), "bytes written to the writer dont equal expected result")
+	})
+	t.Run("fields-disabled-level-info", func(t *testing.T) {
+		w := newWriter()
+		logger := New(w, DEBUG|WARN|ERROR|FATAL)
+		logger.InfoWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		assert.Equal(t, string(w.b), ``, "bytes written to the writer dont equal expected result")
+		assert.False(t, w.called, "writer should not be called")
+	})
+	t.Run("basic-message-disabled-level-debug", func(t *testing.T) {
+		w := newWriter()
+		logger := New(w, INFO|WARN|ERROR|FATAL)
+		logger.DebugWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		assert.Equal(t, string(w.b), ``, "bytes written to the writer dont equal expected result")
+		assert.False(t, w.called, "writer should not be called")
+	})
+	t.Run("basic-message-disabled-level-warn", func(t *testing.T) {
+		w := newWriter()
+		logger := New(w, INFO|DEBUG|ERROR|FATAL)
+		logger.WarnWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		assert.Equal(t, string(w.b), ``, "bytes written to the writer dont equal expected result")
+		assert.False(t, w.called, "writer should not be called")
+	})
+	t.Run("basic-message-disabled-level-error", func(t *testing.T) {
+		w := newWriter()
+		logger := New(w, INFO|WARN|DEBUG|FATAL)
+		logger.ErrorWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		assert.Equal(t, string(w.b), ``, "bytes written to the writer dont equal expected result")
+		assert.False(t, w.called, "writer should not be called")
+	})
+	t.Run("basic-message-disabled-level-fatal", func(t *testing.T) {
+		w := newWriter()
+		logger := New(w, INFO|WARN|ERROR|DEBUG)
+		logger.FatalWithFields("message", func(e Entry) {
+			e.String("userID", "123456")
+			e.String("action", "login")
+			e.String("result", "success")
+		})
+		assert.Equal(t, string(w.b), ``, "bytes written to the writer dont equal expected result")
+		assert.False(t, w.called, "writer should not be called")
+	})
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -521,10 +521,18 @@ func TestOnelogContext(t *testing.T) {
 }
 
 func TestNilOutput(t *testing.T) {
-	logger := New(nil, 0)
-	assert.NotNil(t, logger.w, "Logger output should not be nil")
-	logger.Error("Test output")
-	t.Log("Successfully write to ioutil.Discard output")
+	t.Run("nil-logger", func(t *testing.T) {
+		logger := New(nil, 0)
+		assert.NotNil(t, logger.w, "Logger output should not be nil")
+		logger.Error("Test output")
+		t.Log("Successfully write to ioutil.Discard output")
+	})
+	t.Run("nil-context-logger", func(t *testing.T) {
+		logger := NewContext(nil, 0, "params")
+		assert.NotNil(t, logger.w, "Logger output should not be nil")
+		logger.Error("Test output")
+		t.Log("Successfully write to ioutil.Discard output")
+	})
 }
 
 func TestOnelogHooksWithAndContext(t *testing.T) {


### PR DESCRIPTION
PR adds context logging where grouping of log fields can be done using the `WithContext(contextName string)` signature. Allowing the following possibilities:

```go
parentLogger = Log.New(os.Stdout, INFO)

serviceLogger = parentLogger.WithContextKey("context")
serviceLogger.INFOWithFields("ready to deploy").Int("id", 2343)
// => { message: "ready to deploy", context: {id: 2343}}

orderLogger = serviceLogger.With(func(e onelog.Entry){ e.Int("r", 20) })
orderLogger.INFOWithFields("ready to deploy").Int("id", 2343)
// => { message: "ready to deploy", context:{id: 2343, r:20}}

orderLogger = serviceLogger.Hook(func(e onelog.Entry){ e.Int("r", 20) })
orderLogger.INFOWithFields("ready to deploy").Int("id", 2343)
// => { message: "ready to deploy", r:20, context:{id: 2343}}
```