### PR TITLE
FIxing ophaned code block error

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ logger.InfoWithFields("breaking news !", func(e onelog.Entry) {
 You can always reset the context by calling `WithContext("")` to create a no-context logger from a 
 context logger parent.
 
-```
 
 ## Logging
 


### PR DESCRIPTION
FIx mistake in leaving a code block, which messed up formating for readme.