### PR TITLE
Add defer release of encoder

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -572,6 +572,8 @@ func (l *Logger) finalizeIfContext(entry Entry) {
 
 	// create a new encoder for the final output.
 	entryEnc := gojay.BorrowEncoder(l.w)
+	defer entryEnc.Release()
+
 	entry.enc = entryEnc
 
 	// create dummy entry for applying hooks.


### PR DESCRIPTION
Fixes a possible memory leak where an encoder is not released back into the pool after `borrow`.