### PR TITLE
feat: exit after Fatal, FatalWithFields, and FatalWith chained entries.

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -75,6 +75,7 @@ func (e Entry) Array(k string, obj gojay.MarshalerJSONArray) Entry {
 type ChainEntry struct {
 	Entry
 	disabled bool
+	exit     bool
 }
 
 // Info logs an entry with INFO level.
@@ -87,6 +88,10 @@ func (e ChainEntry) Write() {
 	e.Entry.l.closeEntry(e.Entry)
 	e.Entry.l.finalizeIfContext(e.Entry)
 	e.Entry.enc.Release()
+
+	if e.exit {
+		e.Entry.l.ExitFn(1)
+	}
 }
 
 // String adds a string to the log entry.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/francoispqt/onelog
 
 require (
-	github.com/davecgh/go-spew v1.1.1
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/francoispqt/gojay v0.0.0-20181220093123-f2cc13a668ca
-	github.com/pmezard/go-difflib v1.0.0
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/francoispqt/gojay v0.0.0-20181220093123-f2cc13a668ca h1:F2BD6Vhei4w0rtm4eNpzylNsB07CcCbpYA+xlqMx3mA=
 github.com/francoispqt/gojay v0.0.0-20181220093123-f2cc13a668ca/go.mod h1:H8Wgri1Asi1VevY3ySdpIK5+KCpqzToVswNq8g2xZj4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
Hey,

As of now, Fatal calls do not exit from the app.

Comparing with other loggers mentioned in the benchmark table, I found that all of them have an implementation for the same. Considering this, it would be a great addition to have in onelog as well.

- Logrus: https://github.com/sirupsen/logrus/blob/7d8d63893b994a654b3bc8d16ffd7fb6b9f884a4/logger.go#L221
- Zap: https://github.com/uber-go/zap/blob/f4243df2af592a2e0ccdccb77e1ad44f78d735e5/internal/exit/exit.go
- Zerolog: https://github.com/rs/zerolog/blob/1c6d99b45538810b3e120bc5a1c29fc019918225/log/log.go#L68

Please see my proposed API for the same.
