### PR TITLE
fix: panic in case NewContext is used to initialize logger with Fatal

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -90,7 +90,7 @@ func (e ChainEntry) Write() {
 	e.Entry.enc.Release()
 
 	if e.exit {
-		e.Entry.l.ExitFn(1)
+		e.Entry.l.exit(1)
 	}
 }
 


### PR DESCRIPTION
Hey,

I missed adding ExitFn to `NewContext()` causing a panic.

Have added a patch to fix it along with a scoped `exit` function which checks if ExitFn is nil (since it is exposed) and calls `os.Exit` as a fallback.

Regards